### PR TITLE
Fix invalid NSError instance

### DIFF
--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -1060,7 +1060,7 @@ static KIOEventStore *eventStore;
     if (!onError)
         onError = ^(NSString* errorCode, NSString* message){};
 
-    NSError *error = [[NSError alloc] init];
+    NSError *error = nil;
 
     [self addEvent:event withKeenProperties:nil toEventCollection:eventCollection error:&error onSuccess:onSuccess onError:onError];
 }


### PR DESCRIPTION
Following message was shown in  Xcode console.

> [NSError init] called; this results in an invalid NSError instance. It will raise an exception in a future release. Please call errorWithDomain:code:userInfo: or initWithDomain:code:userInfo:. This message shown only once.