### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ However, the next time they trigger the code that send events (e.g. backgroundin
 
 ##### 3.2.12
 
-+ Skipped 3.2.11 versioning in favor of 3.2.12 to workaround Cocoapods versioning issue.
++ Skipped 3.2.11 versioning in favor of 3.2.12 to workaround CocoaPods versioning issue.
 + Converted KeenClient to use ARC.
 + Renamed all SQLite files with keen\_io\_ prefix.
 + Moved keen\_io\_sqlite3.h import to KIOEventStore.m.


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
