### PR TITLE
Cherry-pick: Move sqlite amalgamation to a subspec

### DIFF
--- a/KeenClientTD.podspec
+++ b/KeenClientTD.podspec
@@ -11,8 +11,13 @@ Pod::Spec.new do |spec|
                       This is a forked project by TD. The original cool project is https://github.com/keenlabs/KeenClient-iOS.
                       DESC
   spec.source       = { :git => 'https://github.com/treasure-data/KeenClient-iOS.git', :tag => 'td_3.2.32' }
-  spec.source_files = 'KeenClient/*.{h,m}','Library/sqlite-amalgamation/*.{h,c}'
+  spec.source_files = 'KeenClient/*.{h,m}'
   spec.public_header_files = 'KeenClient/*.h'
-  spec.private_header_files = 'Library/sqlite-amalgamation/*.h'
   spec.requires_arc = true
+
+  spec.subspec 'keen_sqlite' do |ks|
+    ks.source_files = 'Library/sqlite-amalgamation/*.{h,c}'
+    ks.private_header_files = 'Library/sqlite-amalgamation/*.h'
+    ks.compiler_flags = '-w', '-Xanalyzer', '-analyzer-disable-all-checks'
+  end
 end


### PR DESCRIPTION
commit 00cfff40fcc2761942c1b778b26dee268639e166
Author: Heitor Tashiro Sergent <heitortsergent@gmail.com>
Date:   Thu Jun 11 14:05:43 2015 -0300

    Move sqlite amalgamation to a subspec

    Move sqlite amalgamation to a subspec in order to add compiler flags to its files and stop showing warnings