### PR TITLE
Max uploads per request

### DIFF
--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -1074,7 +1074,7 @@ static KIOEventStore *eventStore;
     if (self.isRunningTests) {
         return 2;
     }
-    return 500;
+    return 400;
 }
 
 - (NSUInteger)maxEventsPerCollection {

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -829,7 +829,6 @@ static KIOEventStore *eventStore;
                 if (finishedUpload == nil || (onSuccess == nil && onError == nil)) return;
                 [finishedUpload addObject:cName];
                 if (error) finalError = error;
-//                NSLog(@"%lu collections finishedUpload: %@. Error: %@", totalNumberOfCollections, finishedUpload, finalError);
                 if (finishedUpload.count == totalNumberOfCollections) {
                     if (finalError) {
                         if (onError) onError(finalError.userInfo[@"code"], finalError.localizedDescription);
@@ -868,7 +867,6 @@ static KIOEventStore *eventStore;
             if (finishedUpload == nil || (completionHandler == nil)) return;
             [finishedUpload addObject:chunkIndex];
             if (error) finalError = error;
-//            NSLog(@"%lu chunks finishedUpload: %@. Error: %@", totalNumberOfChunks, finishedUpload, finalError);
             if (finishedUpload.count == totalNumberOfChunks) {
                 completionHandler(collectionName, finalError);
             }

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -324,6 +324,44 @@
     return [NSDictionary dictionaryWithObject:array forKey:@"receipts"];
 }
 
+- (id)uploadTestHelperWithDataSequence:(NSArray *)dataSequence andStatusCodes:(NSArray *)codes {
+    // set up the partial mock
+    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    client.isRunningTests = YES;
+    id mock = [OCMockObject partialMockForObject:client];
+    
+    // setup data sequence
+    NSMutableArray *serializedDataSequence = [NSMutableArray array];
+    for (NSDictionary *d in dataSequence) {
+        NSDictionary *data = d;
+        if (!data) {
+            data = [self buildResponseJsonWithSuccess:YES AndErrorCode:nil AndDescription:nil];
+        }
+
+        
+        
+        // serialize the faked out response data
+        data = [client handleInvalidJSONInObject:data];
+        NSData *serializedData = [NSJSONSerialization dataWithJSONObject:data
+                                                                 options:0
+                                                                   error:nil];
+        [serializedDataSequence addObject:serializedData];
+    }
+    
+    __block NSUInteger index = 0;
+    [OCMStub([mock sendEvents:[OCMArg any] database:[OCMArg any] table:[OCMArg any] completionHandler:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
+        void (^handler)(NSData *data, NSURLResponse *response, NSError *error);
+        [invocation getArgument:&handler atIndex:5];
+        NSData *serializedData = serializedDataSequence[index];
+        // set up the response we're faking out
+        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL new] statusCode:[codes[index] integerValue] HTTPVersion:nil headerFields:nil];
+        index += 1;
+        handler(serializedData, response, nil);
+    }];
+    
+    return mock;
+}
+
 - (id)uploadTestHelperWithData:(id)data andStatusCode:(NSInteger)code {
     if (!data) {
         data = [self buildResponseJsonWithSuccess:YES AndErrorCode:nil AndDescription:nil];
@@ -679,6 +717,56 @@
     [self uploadWithMock:mock andExpect:^{
         // make sure the files were deleted locally
         XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 2,  @"There should be 1 events after a partial upload.");
+    }];
+}
+
+- (void)testMaxUploadEventsAtOnceSuccess {
+    NSDictionary *result1 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
+    NSDictionary *result2 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
+    NSDictionary *result3 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
+    NSDictionary *result4 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
+    NSDictionary *result5 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
+    NSDictionary *response1 = @{@"receipts": @[result1, result2]};
+    NSDictionary *response2 = @{@"receipts": @[result3, result4]};
+    NSDictionary *response3 = @{@"receipts": @[result5]};
+    id mock = [self uploadTestHelperWithDataSequence:@[response1, response2, response3] andStatusCodes:@[@200, @200, @200]];
+    
+    // add an event
+    [mock addEvent:[NSDictionary dictionaryWithObject:@"apple" forKey:@"a"] toEventCollection:@"foo.bar" error:nil];
+    [mock addEvent:[NSDictionary dictionaryWithObject:@"bapple" forKey:@"b"] toEventCollection:@"foo.bar" error:nil];
+    [mock addEvent:[NSDictionary dictionaryWithObject:@"orange" forKey:@"a"] toEventCollection:@"foo2.bar2" error:nil];
+    [mock addEvent:[NSDictionary dictionaryWithObject:@"borange" forKey:@"b"] toEventCollection:@"foo2.bar2" error:nil];
+    [mock addEvent:[NSDictionary dictionaryWithObject:@"corange" forKey:@"c"] toEventCollection:@"foo2.bar2" error:nil];
+    
+    // and "upload" it
+    [self uploadWithMock:mock andExpect:^{
+        // make sure the files were deleted locally
+        XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"There should be no events after a successful upload.");
+    }];
+}
+
+- (void)testMaxUploadEventsAtOnceFailure {
+    NSDictionary *result1 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
+    NSDictionary *result2 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
+    NSDictionary *result3 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
+    NSDictionary *result4 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
+    NSDictionary *result5 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
+    NSDictionary *response1 = @{};
+    NSDictionary *response2 = @{@"receipts": @[result3, result4]};
+    NSDictionary *response3 = @{@"receipts": @[result5]};
+    id mock = [self uploadTestHelperWithDataSequence:@[response1, response2, response3] andStatusCodes:@[@500, @200, @200]];
+    
+    // add an event
+    [mock addEvent:[NSDictionary dictionaryWithObject:@"apple" forKey:@"a"] toEventCollection:@"foo.bar" error:nil];
+    [mock addEvent:[NSDictionary dictionaryWithObject:@"bapple" forKey:@"b"] toEventCollection:@"foo.bar" error:nil];
+    [mock addEvent:[NSDictionary dictionaryWithObject:@"orange" forKey:@"a"] toEventCollection:@"foo2.bar2" error:nil];
+    [mock addEvent:[NSDictionary dictionaryWithObject:@"borange" forKey:@"b"] toEventCollection:@"foo2.bar2" error:nil];
+    [mock addEvent:[NSDictionary dictionaryWithObject:@"corange" forKey:@"c"] toEventCollection:@"foo2.bar2" error:nil];
+    
+    // and "upload" it
+    [self uploadWithMock:mock andExpect:^{
+        NSLog(@"getTotalEventCount %lu", [[KeenClient getEventStore] getTotalEventCount]);
+        XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 2,  @"There should be 2 events after request #2 fails upload.");
     }];
 }
 

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -745,8 +745,6 @@
 }
 
 - (void)testMaxUploadEventsAtOnceFailure {
-//    NSDictionary *result1 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
-//    NSDictionary *result2 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
     NSDictionary *result3 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
     NSDictionary *result4 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
     NSDictionary *result5 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
@@ -772,8 +770,6 @@
 - (void)testMaxUploadEventsAtOncePartialFailureInCollection {
     NSDictionary *result1 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
     NSDictionary *result2 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
-//    NSDictionary *result3 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
-//    NSDictionary *result4 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
     NSDictionary *result5 = [self buildResultWithSuccess:YES andErrorCode:nil andDescription:nil];
     NSDictionary *response1 = @{@"receipts": @[result1, result2]};
     NSDictionary *response2 = @{};


### PR DESCRIPTION
### Overview
Currently, we are sending events of each collection to a separate endpoint.
We need to support splitting a big request into multiple requests as well.
Setting max uploads per request default to 400 for parity with KeenClient-Java.

### Impact
Should have minimum impact. As the API and end-result upload behavior does not change.

### Regression
Revert